### PR TITLE
use unicode-display_width between >= 1.0.1  and < 2.0

### DIFF
--- a/hirb-unicode.gemspec
+++ b/hirb-unicode.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "hirb-unicode"
 
   s.add_dependency 'hirb', '~> 0.5'
-  s.add_dependency 'unicode-display_width', '~> 0.1.1'
+  s.add_dependency 'unicode-display_width', '~> 1.0', '>= 1.0.1'
   # Use the same test utility as `hirb`
   s.add_development_dependency 'bacon', '>= 1.1.0'
   s.add_development_dependency 'mocha'


### PR DESCRIPTION
update unicode-display_width dependencie.

rake test result is
```
bundle exec rake test
bundle exec bacon -q hirb-unicode.rb /Users/takeshi.nakata/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/hirb-0.7.3/test/*_test.rb
.........................................................................................................................................................................................................................
Finished in 0.202931 seconds.

217 tests, 347 assertions, 0 failures, 0 errors
bundle exec bacon -I. -q test/*_test.rb
.........
Finished in 0.056874 seconds.

9 tests, 15 assertions, 0 failures, 0 errors
```