### PR TITLE
update related gems.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+/vendor

--- a/hirb-unicode.gemspec
+++ b/hirb-unicode.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "hirb-unicode"
 
-  s.add_dependency 'hirb', '~> 0.5'
-  s.add_dependency 'unicode-display_width', '~> 0.1.1'
+  s.add_dependency 'hirb', '~> 0.7.3'
+  s.add_dependency 'unicode-display_width', '~> 1.0',  '>= 1.0.1'
   # Use the same test utility as `hirb`
   s.add_development_dependency 'bacon', '>= 1.1.0'
   s.add_development_dependency 'mocha', '~> 0.12.1'

--- a/hirb-unicode.gemspec
+++ b/hirb-unicode.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'unicode-display_width', '~> 0.1.1'
   # Use the same test utility as `hirb`
   s.add_development_dependency 'bacon', '>= 1.1.0'
-  s.add_development_dependency 'mocha'
-  s.add_development_dependency 'mocha-on-bacon'
+  s.add_development_dependency 'mocha', '~> 0.12.1'
+  s.add_development_dependency 'mocha-on-bacon', '~> 0.2.1'
   s.add_development_dependency 'bacon-bits'
   s.add_development_dependency 'rake'
 


### PR DESCRIPTION
udpate related gems for use rubocop-checkstype_formatter.